### PR TITLE
[mlite] Use QDBusMessage instead of QDBusInterface for remote actions.

### DIFF
--- a/src/mremoteaction.cpp
+++ b/src/mremoteaction.cpp
@@ -124,8 +124,8 @@ void MRemoteAction::trigger()
 {
     Q_D(MRemoteAction);
 
-    QDBusInterface interface(d->serviceName, d->objectPath, d->interface.toLatin1());
-    if (interface.isValid()) {
-        interface.asyncCallWithArgumentList(d->methodName, d->arguments);
-    }
+    QDBusMessage msg = QDBusMessage::createMethodCall(d->serviceName, d->objectPath, d->interface.toLatin1(), d->methodName);
+    msg.setArguments(d->arguments);
+
+    QDBusConnection::sessionBus().asyncCall(msg);
 }


### PR DESCRIPTION
QDBusInterface causes introspection, which can be slow. Since we aren't all that
interested in the outcome of the introspection, just send the message instead.
