### PR TITLE
[mlite] Added sync() function which hints gconf to sync values to the cache

### DIFF
--- a/rpm/mlite-qt5.spec
+++ b/rpm/mlite-qt5.spec
@@ -9,7 +9,7 @@ Name:       mlite-qt5
 # << macros
 
 Summary:    Useful classes originating from MeeGo Touch
-Version:    0.2.2
+Version:    0.2.3
 Release:    1
 Group:      System/Libraries
 License:    LGPL v2.1
@@ -60,7 +60,7 @@ export QT_SELECT=5
 %qmake5  \
     VERSION=%{version}
 
-make %{?jobs:-j%jobs}
+make %{?_smp_mflags}
 
 # >> build post
 # << build post

--- a/rpm/mlite-qt5.yaml
+++ b/rpm/mlite-qt5.yaml
@@ -1,6 +1,6 @@
 Name: mlite-qt5
 Summary: Useful classes originating from MeeGo Touch
-Version: 0.2.2
+Version: 0.2.3
 Release: 1
 Group: System/Libraries
 License: LGPL v2.1

--- a/src/mgconfitem.h
+++ b/src/mgconfitem.h
@@ -122,6 +122,13 @@ public:
     */
     QStringList listDirs() const;
 
+    /*! Request gconf to sync value(s) which are not yet synced to the cache.
+        Sometimes values may not be synced because eventually this just hints
+        gconf to start sync.
+
+        Returns true if there's no errors and false on error.
+    */
+    bool sync();
 
 Q_SIGNALS:
     /*! Emitted when the value of this item has changed.


### PR DESCRIPTION
If changing gconf value and rebooting the device immediately after that may cause data loss. Calling sync, it can be ensured that gconf has been hinted that there are data which should be cached.
