### PR TITLE
[mlite] Avoid include guard conflict with mlite-global.h

### DIFF
--- a/src/mlite-global.h
+++ b/src/mlite-global.h
@@ -1,5 +1,5 @@
-#ifndef GLOBAL_H
-#define GLOBAL_H
+#ifndef MLITE_GLOBAL_H
+#define MLITE_GLOBAL_H
 
 #include <QtCore/qglobal.h>
 


### PR DESCRIPTION
Pointed out here
https://together.jolla.com/question/30505/mlite5-mlite-globalh-has-wrong-define-on-top/
