### PR TITLE
[packaging] Add Qt5Gui to build requirements

### DIFF
--- a/rpm/mlite-qt5.spec
+++ b/rpm/mlite-qt5.spec
@@ -20,6 +20,7 @@ Requires(post): /sbin/ldconfig
 Requires(postun): /sbin/ldconfig
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Core)
+BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(dconf)
 


### PR DESCRIPTION
It's needed by ut_mdconfgroup
