### PR TITLE
[mlite] Fix assert while resolving properties.

### DIFF
--- a/src/mdconfgroup.cpp
+++ b/src/mdconfgroup.cpp
@@ -355,8 +355,11 @@ void MDConfGroupPrivate::resolveProperties(const QByteArray &scopePath)
     // Recurse into children with relative paths and resolve their properties as well.
     for (int i = 0; i < children.count(); ++i) {
         MDConfGroup * const child = children.at(i);
-        if (!child->priv->path.isEmpty() && !child->priv->path.startsWith(QLatin1Char('/')))
+        if (child->priv->absolutePath.isEmpty()
+                && !child->priv->path.isEmpty()
+                && !child->priv->path.startsWith(QLatin1Char('/'))) {
             children.at(i)->priv->resolveProperties(absolutePath);
+        }
     }
 }
 


### PR DESCRIPTION
Bindings evaluation can result in a child being resolved
while properties for the parent are being read. Don't resolve
the child's properties a second time if that happens.
