### PR TITLE
[mlite] Do not install translators from desktop files

### DIFF
--- a/src/mdesktopentry_p.h
+++ b/src/mdesktopentry_p.h
@@ -57,9 +57,6 @@ public:
     //! A map for storing the desktop entries keys and their corresponding values
     QMap<QString, QString> desktopEntriesMap;
 
-    //! A map for storing translators for translation catalogs
-    static QMap<QString, QSharedPointer<QTranslator> > translators;
-
     /*!
      * Returns the boolean value of a key.
      *
@@ -79,6 +76,15 @@ public:
 
     //! Flag to indicate whether the desktop entry is valid during parsing
     bool valid;
+
+    //! Cached translated name
+    mutable QString translatedName;
+
+    /*!
+     * Loads a QTranslator from X-MeeGo-Translation-Catalog
+     * \return A translator for specified catalog, or null
+     */
+    QTranslator *loadTranslator() const;
 
 protected:
     /*

--- a/tests/ut_mdesktopentry.cpp
+++ b/tests/ut_mdesktopentry.cpp
@@ -371,8 +371,21 @@ void UtMDesktopEntry::localization_data()
             "Name[sr@Latn]=l_vFoo\n",
             "sr_YU@Latn", "l_vFoo");
 
-    Helper::add("logical", "X-MeeGo-Logical-Id=LogicalFoo", QString(), "LogicalFooTranslated");
+    QString entry = QString("X-MeeGo-Logical-Id=LogicalBar\n"
+                            "X-MeeGo-Translation-Catalog=%1/ut_mdesktopentry2.qm")
+            .arg(QCoreApplication::applicationDirPath());
+
+    Helper::add("logical_fromCatalog", entry, QString(), "LogicalBarTranslated");
+    Helper::add("logical_global", "X-MeeGo-Logical-Id=LogicalFoo", QString(), "LogicalFooTranslated");
     Helper::add("logical_noTranslation", "X-MeeGo-Logical-Id=LogicalFooNoTr", QString(), "Foo");
+    Helper::add("logical_other", "X-MeeGo-Logical-Id=LogicalBar", QString(), "Foo");
+
+    QTranslator *const translator = new QTranslator;
+    const bool loadOk = translator->load("ut_mdesktopentry",
+            QCoreApplication::instance()->applicationDirPath());
+    Q_ASSERT(loadOk);
+    qApp->installTranslator(translator);
+    Q_ASSERT(qtTrId("LogicalFoo") == "LogicalFooTranslated");
 }
 
 void UtMDesktopEntry::localization()
@@ -381,13 +394,6 @@ void UtMDesktopEntry::localization()
     QFETCH(QString, lang);
     QFETCH(QString, expected);
 
-    QTranslator *const translator = new QTranslator;
-    const bool loadOk = translator->load("ut_mdesktopentry",
-            QCoreApplication::instance()->applicationDirPath());
-    Q_ASSERT(loadOk);
-    qApp->installTranslator(translator);
-    Q_ASSERT(qtTrId("LogicalFoo") == "LogicalFooTranslated");
-
     if (!lang.isEmpty()) {
         qputenv("LANG", lang.toLocal8Bit());
     }
@@ -395,6 +401,7 @@ void UtMDesktopEntry::localization()
     MDesktopEntry entry(createDesktopEntry(values));
     QCOMPARE(entry.nameUnlocalized(), QString("Foo"));
     QCOMPARE(entry.name(), expected);
+    QVERIFY2(qtTrId("LogicalBar") != "LogicalBarTranslated", "MDesktopEntry: A translator was installed globally");
 }
 
 QString UtMDesktopEntry::createDesktopEntry(const Values &values)

--- a/tests/ut_mdesktopentry.pro
+++ b/tests/ut_mdesktopentry.pro
@@ -1,6 +1,6 @@
 include(testapplication.pri)
 
-TRANSLATIONS = ut_mdesktopentry.ts
+TRANSLATIONS = ut_mdesktopentry.ts ut_mdesktopentry2.ts
 
 lrelease.input = TRANSLATIONS
 lrelease.output = ${QMAKE_FILE_BASE}.qm

--- a/tests/ut_mdesktopentry2.ts
+++ b/tests/ut_mdesktopentry2.ts
@@ -1,0 +1,8 @@
+<!DOCTYPE TS>
+<TS>
+  <context>
+    <message id="LogicalBar">
+      <translation>LogicalBarTranslated</translation>
+    </message>
+  </context>
+</TS>


### PR DESCRIPTION
In Qt, every translation goes through list of globally installed
translators linearly. Non-discriminately loading translation
catalogs specified in .desktop files risks name clashes and slows
down translation.
