### PR TITLE
Don't require trailing semicolon

### DIFF
--- a/src/mdesktopentry.cpp
+++ b/src/mdesktopentry.cpp
@@ -150,16 +150,6 @@ bool MDesktopEntry::readDesktopFile(QIODevice &device, QMap<QString, QString> &d
                 if (!desktopEntriesMap.contains(desktopKey)) {
                     QString value = keyValueRE.cap(2);
 
-                    // Check whether this is a known multivalue key
-                    if (desktopKey == CategoriesKey || desktopKey == OnlyShowInKey ||
-                            desktopKey == NotShowInKey || desktopKey == MimeTypeKey) {
-                        if (value.endsWith("\\;") || !value.endsWith(';')) {
-                            // Multivalue doesn't end with a semicolon so mark the desktop entry invalid
-                            qDebug() << "Value for multivalue key" << desktopKey << "does not end in a semicolon";
-                            valid = false;
-                        }
-                    }
-
                     // Add the value to the desktop entries map
                     desktopEntriesMap.insert(desktopKey, value);
                 } else {
@@ -200,6 +190,11 @@ QStringList MDesktopEntryPrivate::stringListValue(const QString &key) const
 {
     QStringList list;
     QString value = desktopEntriesMap.value(key);
+
+    // Add trailing semicolon to make the code below work when it's missing
+    if (!value.endsWith(";")) {
+        value += ";";
+    }
 
     // Split the string using ; but not \; as the separator
     const int valueLength = value.length();

--- a/tests/ut_mdesktopentry.cpp
+++ b/tests/ut_mdesktopentry.cpp
@@ -142,8 +142,8 @@ void UtMDesktopEntry::isValid_data()
     };
     foreach (const QString &key, multivalueKeys) {
         MultivalueHelper::add("endSemicolon", key, "foo;", true);
-        MultivalueHelper::add("noEndSemicolon", key, "foo", false);
-        MultivalueHelper::add("escapedEndSemicolon", key, "foo\\;", false);
+        MultivalueHelper::add("noEndSemicolon", key, "foo", true);
+        MultivalueHelper::add("escapedEndSemicolon", key, "foo\\;", true);
         MultivalueHelper::add("endSemicolonWhitespace", key, "foo; ", true);
     }
 
@@ -238,7 +238,7 @@ void UtMDesktopEntry::values_data()
     values["Comment"] = "Lorem ipsum";
     values["Icon"] = "application/foo";
     values["Hidden"] = "true";
-    values["OnlyShowIn"] = "KDE;";
+    values["OnlyShowIn"] = "KDE";
     values["NotShowIn"] = "GNOME;XFCE;";
     values["TryExec"] = "true";
     values["Exec"] = "true";


### PR DESCRIPTION
"The multiple values should be separated by a semicolon and the value of the
key may be optionally terminated by a semicolon."

 -- http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s03.html