### PR TITLE
[mlite] Don't call Qt signals directly from glib events. Fixes MER#1232

### DIFF
--- a/src/mdconfgroup.cpp
+++ b/src/mdconfgroup.cpp
@@ -300,6 +300,11 @@ void MDConfGroup::propertyChanged()
     }
 }
 
+void MDConfGroup::notifyChanged(const QByteArray &basePath, const QByteArray &key)
+{
+    priv->notify(basePath, key);
+}
+
 void MDConfGroupPrivate::connectToClient()
 {
     Q_ASSERT(!client);
@@ -424,6 +429,7 @@ void MDConfGroupPrivate::changed(
         const QByteArray basePath = absoluteKey.mid(0, pathLength);
         const QByteArray key = absoluteKey.mid(pathLength);
 
-        priv->notify(basePath, key);
+        QMetaObject::invokeMethod(priv->group, "notifyChanged", Qt::QueuedConnection,
+                                    Q_ARG(QByteArray, basePath), Q_ARG(QByteArray, key));
     }
 }

--- a/src/mdconfgroup.h
+++ b/src/mdconfgroup.h
@@ -221,6 +221,7 @@ protected:
 
 private slots:
     void propertyChanged();
+    void notifyChanged(const QByteArray &basePath, const QByteArray &key);
 
 private:
     friend class MDConfGroupPrivate;

--- a/src/mgconfitem.cpp
+++ b/src/mgconfitem.cpp
@@ -68,6 +68,11 @@ void MGConfItemPrivate::notify_trampoline(DConfClient *, gchar *, GStrv, gchar *
     item->update_value(true);
 }
 
+void MGConfItem::emitValueChanged()
+{
+    emit valueChanged();
+}
+
 void MGConfItem::update_value(bool emit_signal)
 {
     QVariant new_value;
@@ -84,7 +89,7 @@ void MGConfItem::update_value(bool emit_signal)
     if (new_value != priv->value || new_value.userType() != priv->value.userType()) {
         priv->value = new_value;
         if (emit_signal)
-            emit valueChanged();
+            QMetaObject::invokeMethod(this, "emitValueChanged", Qt::QueuedConnection);
     }
 }
 

--- a/src/mgconfitem.h
+++ b/src/mgconfitem.h
@@ -139,7 +139,9 @@ private:
     friend struct MGConfItemPrivate;
     struct MGConfItemPrivate *priv;
 
+private slots:
     void update_value(bool emit_signal);
+    void emitValueChanged();
 };
 
 #endif // MGCONFITEM_H

--- a/tests/ut_mgconfitem.cpp
+++ b/tests/ut_mgconfitem.cpp
@@ -86,7 +86,7 @@ void UtMGConfItem::basicTest()
     QSignalSpy spy2(&item2, SIGNAL(valueChanged()));
     item2.set(value1);
     QCOMPARE(item2.value(), value1);
-    QCOMPARE(spy2.count(), 1);
+    QTRY_COMPARE(spy2.count(), 1);
 
     waitForSignal(&item1, SIGNAL(valueChanged()));
     QTRY_COMPARE(item1.value(), value1);
@@ -96,7 +96,7 @@ void UtMGConfItem::basicTest()
     QSignalSpy spy1(&item1, SIGNAL(valueChanged()));
     item1.set(value2);
     QCOMPARE(item1.value(), value2);
-    QCOMPARE(spy1.count(), 1);
+    QTRY_COMPARE(spy1.count(), 1);
 
     waitForSignal(&item2, SIGNAL(valueChanged()));
     QTRY_COMPARE(item2.value(), value2);


### PR DESCRIPTION
This can hit https://bugreports.qt.io/browse/QTBUG-32859, which can lead
to some very hard to find memory leaks.