### PR TITLE
Don't emit Qt signals directly from glib events. Fixes MER#1232

### DIFF
--- a/src/mdconf_p.h
+++ b/src/mdconf_p.h
@@ -12,9 +12,22 @@
 #include <dconf/dconf.h>
 
 #include <QVariant>
+#include <QEvent>
 
 namespace MDConf
 {
+    class Event : public QEvent
+    {
+    public:
+        enum { TYPE = QEvent::User };
+
+        Event(const char *aPrefix, GStrv aChanges) : QEvent((Type)TYPE),
+            prefix(aPrefix), changes(aChanges) {}
+
+        const char *prefix;
+        GStrv changes;
+    };
+
 
 QVariant convertValue(GVariant *value, int typeHint = QMetaType::UnknownType);
 bool convertValue(const QVariant &variant, GVariant **valp);


### PR DESCRIPTION
This way, signal emission is not delayed, application behaviour is not affected and yet deferred deletion works (verified).