### PR TITLE
Fix setting a path in the MDConfGroup constructor

### DIFF
--- a/src/mdconfgroup.cpp
+++ b/src/mdconfgroup.cpp
@@ -111,12 +111,6 @@ void MDConfGroup::resolveMetaObject(int propertyOffset)
         propertyOffset = staticMetaObject.propertyCount();
     priv->propertyOffset = propertyOffset;
 
-    // If there's no Q_OBJECT declaration or dynamic meta-object in the derived type there's
-    // nothing to do here so abort.
-    if (metaObject == &staticMetaObject) {
-        return;
-    }
-
     // Connect all the notify signals of the derived type's properties to the propertyChanged()
     // slot.
     for (int i = propertyOffset; i < metaObject->propertyCount(); ++i) {

--- a/tests/ut_mdconfgroup.cpp
+++ b/tests/ut_mdconfgroup.cpp
@@ -426,7 +426,7 @@ void UtMDConfGroup::value()
     const QVariant defaultValue = QStringLiteral("default");
 
     MDConfGroup group1;
-    MDConfGroup group2;
+    MDConfGroup group2(QStringLiteral("/mlite-tests/ut_mdconfgroup/scopes/scope1/nested/properties"));
 
     group1.setObjectName("group1");
     group2.setObjectName("group2");
@@ -434,7 +434,6 @@ void UtMDConfGroup::value()
     QSignalSpy propertySpy(&group2, SIGNAL(valueChanged(QString)));
 
     group1.setPath(QStringLiteral("/mlite-tests/ut_mdconfgroup/scopes/scope1/nested/properties"));
-    group2.setPath(QStringLiteral("/mlite-tests/ut_mdconfgroup/scopes/scope1/nested/properties"));
 
     QCOMPARE(group1.isSynchronous(), false);
     QCOMPARE(group2.isSynchronous(), false);


### PR DESCRIPTION
…1322

Open the dconf connection in resolveMetaObject() irrespective of
whether there is a derivative meta object to resolve so that the value
functions can still be utilized.
